### PR TITLE
 Platform command usage without commander #5 

### DIFF
--- a/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/annotation/BukkitCommand.java
+++ b/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/annotation/BukkitCommand.java
@@ -1,0 +1,50 @@
+package dev.temez.springlify.starter.annotation;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+/**
+ * The {@code VelocityCommand} annotation is a custom annotation used to mark classes
+ * as Velocity commands, for continuous auto registering with spring post processor.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * @VelocityComand(command="mycommand", alias = {"alias1", "alias2"})
+ * public class MyCommand implements CommandExecutor {
+ *
+ *  // Command execution logic
+ *
+ * }
+ * }</pre>
+ *
+ * <p>In this example, `MyCommand` is marked as a Velocity command with the primary command
+ * "mycommand" and two aliases "alias1" and "alias2."
+ *
+ * @since 0.7.0.0-RC1
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component
+@Documented
+public @interface BukkitCommand {
+
+  /**
+   * Alias for the {@link Component} annotation's value attribute.
+   * Specifies the name of the bean.
+   *
+   * @return The primary bean name.
+   */
+  @AliasFor(annotation = Component.class)
+  String value() default "";
+
+  /**
+   * Specifies the primary command name.
+   *
+   * @return The primary command name.
+   */
+  @NotNull
+  String command();
+}

--- a/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/initializer/CommandHandlerInitializer.java
+++ b/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/initializer/CommandHandlerInitializer.java
@@ -1,0 +1,46 @@
+package dev.temez.springlify.starter.initializer;
+
+import dev.temez.springlify.starter.annotation.BukkitCommand;
+import dev.temez.springlify.starter.server.ServerPlatformAdapter;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+public final class CommandHandlerInitializer implements BeanPostProcessor {
+
+  @NotNull
+  ServerPlatformAdapter serverPlatformAdapter;
+
+  @Lazy
+  public CommandHandlerInitializer(@NotNull ServerPlatformAdapter serverPlatformAdapter) {
+    this.serverPlatformAdapter = serverPlatformAdapter;
+  }
+
+  @Override
+  public @NotNull Object postProcessAfterInitialization(@NotNull Object bean, @NotNull String beanName) throws BeansException {
+    Class<?> beanClass = bean.getClass();
+    if (bean instanceof CommandExecutor executor && !(bean instanceof JavaPlugin)) {
+      BukkitCommand commandAnnotation = beanClass.getAnnotation(BukkitCommand.class);
+      if (commandAnnotation == null) {
+        log.warn("{} implements CommandExecutor but is not annotated with @BukkitCommand, so it won't be registered.", beanClass.getName());
+        return bean;
+      }
+      serverPlatformAdapter.registerCommandExecutor(commandAnnotation.command(), executor);
+      return bean;
+    }
+    if (beanClass.isAnnotationPresent(BukkitCommand.class)) {
+      log.warn("Class, annotated with @BukkitCommand {} should implement CommandExecutor.", beanClass.getName());
+    }
+    return bean;
+  }
+}

--- a/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/server/BukkitServerPlatformAdapter.java
+++ b/springlify-starter/springlify-starter-bukkit/src/main/java/dev/temez/springlify/starter/server/BukkitServerPlatformAdapter.java
@@ -4,6 +4,9 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
@@ -54,5 +57,28 @@ public final class BukkitServerPlatformAdapter implements ServerPlatformAdapter 
   public void unregisterEventListener(@NotNull Object listener) {
     HandlerList.unregisterAll((Listener) listener);
     log.debug("Unregistered event listener: {}", listener.getClass().getSimpleName());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @param command         The command to register.
+   * @param commandExecutor The command executor.
+   * @param alias           The command aliases.
+   */
+  @Override
+  public void registerCommandExecutor(@NotNull String command, @NotNull Object commandExecutor, @NotNull String... alias) {
+    CommandExecutor executor = (CommandExecutor) commandExecutor;
+    PluginCommand pluginCommand = plugin.getCommand(command);
+    if (pluginCommand == null) {
+      log.warn("It seems, you forgot to add the command '{}' to plugin.yml", command);
+      return;
+    }
+    pluginCommand.setExecutor(executor);
+    log.debug("Registered {} as a command executor.", commandExecutor.getClass().getSimpleName());
+    if (executor instanceof TabCompleter tabCompleter) {
+      pluginCommand.setTabCompleter(tabCompleter);
+      log.debug("Registered {} as a tab completer.", commandExecutor.getClass().getSimpleName());
+    }
   }
 }

--- a/springlify-starter/springlify-starter-bukkit/src/test/java/dev/temez/springlify/starter/initializer/CommandInitializerTest.java
+++ b/springlify-starter/springlify-starter-bukkit/src/test/java/dev/temez/springlify/starter/initializer/CommandInitializerTest.java
@@ -1,0 +1,71 @@
+package dev.temez.springlify.starter.initializer;
+
+import dev.temez.springlify.starter.annotation.BukkitCommand;
+import dev.temez.springlify.starter.server.ServerPlatformAdapter;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import static org.mockito.Mockito.*;
+
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+class CommandInitializerTest {
+
+  ServerPlatformAdapter serverPlatformAdapter = mock(ServerPlatformAdapter.class);
+
+  BeanPostProcessor eventHandlerInitializer = new CommandHandlerInitializer(serverPlatformAdapter);
+
+  @Test
+  void givenClassWithoutAnnotation_whenPostProcessAfterInitialization_thenShouldNotBeRegistered() {
+    NonAnnotatedCommandExecutor executor = new NonAnnotatedCommandExecutor();
+    eventHandlerInitializer.postProcessAfterInitialization(executor, "test");
+
+    verify(serverPlatformAdapter, times(0)).registerCommandExecutor(eq("test"), any());
+  }
+
+
+  @Test
+  void givenAnnotatedClass_whenPostProcessAfterInitialization_thenShouldNotBeRegistered() {
+    AnnotatedClass executor = new AnnotatedClass();
+    eventHandlerInitializer.postProcessAfterInitialization(executor, "test");
+
+    verify(serverPlatformAdapter, times(0)).registerCommandExecutor(eq("test"), any());
+  }
+
+  @Test
+  void givenAnnotatedCommandExecutor_whenPostProcessAfterInitialization_thenShouldBeRegistered() {
+    AnnotatedCommandExecutor executor = new AnnotatedCommandExecutor();
+
+    eventHandlerInitializer.postProcessAfterInitialization(executor, "test");
+
+    verify(serverPlatformAdapter, times(1)).registerCommandExecutor(eq("test"), any());
+  }
+
+
+  private static class NonAnnotatedCommandExecutor implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+      return false;
+    }
+  }
+
+  private static class AnnotatedClass {
+
+  }
+
+  @BukkitCommand(command = "test")
+  private static class AnnotatedCommandExecutor implements CommandExecutor {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+      return false;
+    }
+  }
+
+}

--- a/springlify-starter/springlify-starter-bukkit/src/test/java/dev/temez/springlify/starter/server/BukkitServerPlatformAdapterTest.java
+++ b/springlify-starter/springlify-starter-bukkit/src/test/java/dev/temez/springlify/starter/server/BukkitServerPlatformAdapterTest.java
@@ -2,18 +2,22 @@ package dev.temez.springlify.starter.server;
 
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
+import org.bukkit.command.*;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.List;
+
 import static org.mockito.Mockito.*;
 
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class BukkitServerPlatformAdapterTest {
 
@@ -41,6 +45,50 @@ public class BukkitServerPlatformAdapterTest {
       serverPlatformAdapter.unregisterEventListener(listener);
 
       handlerList.verify(() -> HandlerList.unregisterAll(listener), times(1));
+    }
+  }
+
+  @Test
+  public void givenCommandExecutor_whenRegisterCommandExecutor_thenRegister() {
+    PluginCommand command = mock(PluginCommand.class);
+    when(plugin.getCommand(anyString())).thenReturn(command);
+    CommandExecutor executor = mock(CommandExecutor.class);
+
+    serverPlatformAdapter.registerCommandExecutor("test", executor);
+
+    verify(command, times(1)).setExecutor(executor);
+  }
+
+  @Test
+  public void givenCommandExecutorWithTabCompleter_whenRegisterCommandExecutor_thenRegister() {
+    PluginCommand command = mock(PluginCommand.class);
+    when(plugin.getCommand(anyString())).thenReturn(command);
+    CommandExecutorWithTabCompleter executor = mock(CommandExecutorWithTabCompleter.class);
+
+    serverPlatformAdapter.registerCommandExecutor("test", executor);
+
+    verify(command, times(1)).setExecutor(executor);
+    verify(command, times(1)).setTabCompleter(executor);
+  }
+
+  @Test
+  public void givenNoCommandFoundInPlugin_whenRegisterCommandExecutor_thenShouldNotBeRegisteredAndThrowException() {
+    when(plugin.getCommand(anyString())).thenReturn(null);
+    CommandExecutorWithTabCompleter executor = mock(CommandExecutorWithTabCompleter.class);
+
+    serverPlatformAdapter.registerCommandExecutor("test", executor);
+  }
+
+  private static class CommandExecutorWithTabCompleter implements CommandExecutor, TabCompleter {
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+      return false;
+    }
+
+    @Override
+    public @Nullable @Unmodifiable List<String> onTabComplete(@NotNull CommandSender commandSender, @NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+      return List.of();
     }
   }
 }

--- a/springlify-starter/springlify-starter-commons/src/main/java/dev/temez/springlify/starter/server/ServerPlatformAdapter.java
+++ b/springlify-starter/springlify-starter-commons/src/main/java/dev/temez/springlify/starter/server/ServerPlatformAdapter.java
@@ -26,4 +26,13 @@ public interface ServerPlatformAdapter {
    * @param listener the event listener to be unregistered
    */
   void unregisterEventListener(@NotNull Object listener);
+
+  /**
+   * Registers a command executor with the platform (e.g., a server) associated with the plugin.
+   *
+   * @param command         The command to register.
+   * @param commandExecutor The command executor.
+   * @param alias           The command aliases.
+   */
+  void registerCommandExecutor(@NotNull String command, @NotNull Object commandExecutor, @NotNull String... alias);
 }


### PR DESCRIPTION
- Added platform-specific command handler registration
- Implemented CommandHandlerInitializer on Bukkit for CommandExecutor and TabCompleter registration
